### PR TITLE
Research title and description

### DIFF
--- a/research.html
+++ b/research.html
@@ -61,13 +61,19 @@
 									<article class="box page-content">
 
 										<header>
-											<h2>Our Research (or some title)</h2>
+											<h2>Research Topics</h2>
 										</header>
 
 										<section>
 											<p class="description">
-												High-level overview of our research. What are the common tools/approaches
-												that unite all of the research areas detailed below?
+												<!-- High-level overview of our research. What are the common tools/approaches
+                                                that unite all of the research areas detailed below? -->
+                                                Our group uses computer simulations to understand and control molecular 
+                                                scale driving forces for a wide range of applications spanning biotechnology 
+                                                to fuel combustion. We develop new methods that expand the capabilities of 
+                                                molecular simulation and use advanced research computing resources to solve 
+                                                challenging problems in the area of computational molecular science. A few 
+                                                representative projects are described below.
 											</p>
 										</section>
 
@@ -316,7 +322,7 @@
 												<div class="col-3 col-6-medium col-12-small">
 													<!-- MDS blog post -->
 														<section class="box feature">
-															<h3><a href="#">Molecular Data Science</a></h3>
+                                                            <h3><a href="#">Molecular<br>Data Science</a></h3>
 															<a href="#" class="image featured"><img src="images/pic01.jpg" alt="" /></a>
 															<p>
 																Description of MDS blog post.
@@ -326,7 +332,7 @@
 												<div class="col-3 col-6-medium col-12-small">
 													<!-- Biomolecule blog post -->
 														<section class="box feature">
-															<h3><a href="#">Biomolecular Simulations</a></h3>
+                                                            <h3><a href="#">Biomolecular<br>Simulations</a></h3>
 															<a href="#" class="image featured"><img src="images/pic02.jpg" alt="" /></a>
 															<p>
 																Description of biomolecular sims blog post.
@@ -336,7 +342,7 @@
 												<div class="col-3 col-6-medium col-12-small">
 													<!-- Reactions blog post -->
 														<section class="box feature">
-															<h3><a href="#">Reaction Networks</a></h3>
+                                                            <h3><a href="#">Reaction<br>Networks</a></h3>
 															<a href="#" class="image featured"><img src="images/pic03.jpg" alt="" /></a>
 															<p>
 																Description of reaction networks blog post.
@@ -346,7 +352,7 @@
 												<div class="col-3 col-6-medium col-12-small">
 													<!-- Clean energy blog post -->
 														<section class="box feature">
-															<h3><a href="#">Clean Energy</a></h3>
+                                                            <h3><a href="#">Clean Energy<br>Materials</a></h3>
 															<a href="#" class="image featured"><img src="images/pic04.jpg" alt="" /></a>
 															<p>
 																Description of clean energy blog post.


### PR DESCRIPTION
Changed <b>"Our Research (Or Some Title)"</b> to <b>"Research Topics"</b> and added the description written by @pfaendtner in #25 . 

I also made all research topics span 2 lines at the bottom in the blogs section since some were on 2 lines and others were on 1, throwing off how the images lined up in that section. Change shown below.

<b>Before:</b>
![image](https://user-images.githubusercontent.com/24407156/45315396-2ec76800-b4e9-11e8-935f-c21ab3ed24da.png)

<b>After:</b>
![image](https://user-images.githubusercontent.com/24407156/45315435-43a3fb80-b4e9-11e8-8b50-b8bd89f9ee51.png)
